### PR TITLE
hotfix/orange-893-ssl-for-db-migration

### DIFF
--- a/config/helpers.js
+++ b/config/helpers.js
@@ -1,0 +1,23 @@
+// This file must not use anything that requires babel compilation because its
+// contents run without babel in some cases, such as when doing DB migrations.
+const logger = require('./winston');
+
+function ensureConnectionIsEncrypted(sequelize) {
+    sequelize.query('select 1 as "dummy string"', {
+        type: sequelize.QueryTypes.SELECT,
+    })
+    .then(() => {
+        logger.info('Sequelize is not throwing SSL-related errors, so we assume SSL is configured correctly.');
+    })
+    .catch((err) => {
+        if (err.message === 'self signed certificate in certificate chain') {
+            logger.error(`Sequelize is throwing error "${err.message}", which it does seemingly any time the certificate is invalid. Ensure your MESSAGING_SERVICE_PG_CA_CERT is set correctly. Aborting.`);
+        } else {
+            logger.error(`Error attempting to verify the sequelize connection is SSL encrypted. Sequelize reports: "${err.message}". Aborting.`);
+        }
+        process.exit(1);
+    });
+}
+module.exports = {
+    ensureConnectionIsEncrypted,
+};

--- a/config/sequelize.js
+++ b/config/sequelize.js
@@ -2,6 +2,7 @@ import Sequelize from 'sequelize';
 import _ from 'lodash';
 import config from './config';
 import logger from './winston';
+import { ensureConnectionIsEncrypted } from './helpers';
 
 let dbLogging;
 if (config.env === 'test') {
@@ -25,6 +26,7 @@ if (config.postgres.sslEnabled) {
         sequelizeOptions.dialectOptions = {
             ssl: {
                 ca: config.postgres.sslCaCert,
+                rejectUnauthorized: true,
             },
         };
     }
@@ -36,6 +38,10 @@ const sequelize = new Sequelize(
     config.postgres.password,
     sequelizeOptions
 );
+
+if (config.postgres.sslEnabled) {
+    ensureConnectionIsEncrypted(sequelize);
+}
 
 const User = sequelize.import('../server/models/user.model');
 const Device = sequelize.import('../server/models/device.model');


### PR DESCRIPTION
# NOTE!!! The info below is only mostly-accurate and copied straight from the messaging service. I copied it here because it's a ton of info and it's super detailed--it's just too much info for me to take the time to fix in writing right here. If you want to thoroughly review this PR correctly, come talk to me.

# What does this PR do?
Two things:
1. Encrypts the connection between Node.js and Postgres when running the DB migration.

2. 
(Both when running the server and when running the migration...)
When `MESSAGING_SERVICE_PG_SSL_ENABLED=true`, it causes sequelize to check to ensure that the connection to postgres is encrypted. It logs an info message if successful, and an error message if not.

# Related JIRA tickets:
https://jira.amida.com/browse/ORANGE-893

# How should this be manually tested?

## Case A: `MESSAGING_SERVICE_PG_SSL_ENABLED=false`:

(Both when running the server and when running the migration...)
When `MESSAGING_SERVICE_PG_SSL_ENABLED=false`, no messages about the encrypted state of the connection will be logged, and everything (e.g. `yarn start`, `yarn migrate`, `yarn migrate:undo`) should just work as expected.

## Case B:  `MESSAGING_SERVICE_PG_SSL_ENABLED=true` and `MESSAGING_SERVICE_PG_CA_CERT` is configured correctly.

(Both when running the server and when running the migration...)
Set `MESSAGING_SERVICE_PG_SSL_ENABLED=true`, and configure `MESSAGING_SERVICE_PG_CA_CERT` correctly (see following info).

> The easiest way to get a correct SSL cert when using Postgres running on RDS is:
> Download the RDS standard cert from here: https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem).
> (For more info about this cert, see this: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html )

Now that you have the cert...

Since `MESSAGING_SERVICE_PG_CA_CERT` is supposed to equal the cert itself, not the path to the cert, and since `nodeenv` / `.env` choke on this, the easiest way to set `MESSAGING_SERVICE_PG_CA_CERT` is to do it on the command line with your command, for example like this:

```sh
MESSAGING_SERVICE_PG_CA_CERT=$(cat /path/to/your/downloaded/rds-combined-ca-bundle.pem) THE_COMMAND
```
where THE_COMMAND would be `yarn start`, `yarn migrate`, or `yarn migrate:undo`

Expected outcome: You should see a logger info message saying SSL is working correctly.

And whatever THE_COMMAND was, it should run successfully.

## Case C: `MESSAGING_SERVICE_PG_SSL_ENABLED=true` but the cert is configured incorrectly.

1. Set `MESSAGING_SERVICE_PG_CA_CERT` to anything that is invalid.
2. `yarn start`

You should see this error message:

> `Sequelize is throwing error "self signed certificate in certificate chain", which it does seemingly any time the certificate is invalid. Ensure your MESSAGING_SERVICE_PG_CA_CERT is set correctly.`
