### PR TITLE
Update config/express.js

### DIFF
--- a/config/express.js
+++ b/config/express.js
@@ -74,13 +74,6 @@ app.use((req, res, next) => {
     return next(err);
 });
 
-// log error in winston transports except when executing test suite
-if (config.env !== 'test') {
-    app.use(expressWinston.errorLogger({
-        winstonInstance,
-    }));
-}
-
 // error handler, send stacktrace only during development
 app.use((err, req, res, next) => // eslint-disable-line no-unused-vars
     res.status(err.status).json({
@@ -88,5 +81,12 @@ app.use((err, req, res, next) => // eslint-disable-line no-unused-vars
         stack: config.env === 'development' ? err.stack : {},
     })
 );
+
+// log error in winston transports except when executing test suite
+if (config.env !== 'test') {
+    app.use(expressWinston.errorLogger({
+        winstonInstance,
+    }));
+}
 
 export default app;


### PR DESCRIPTION
Moves the order of the winston middleware so that our error handling middlewear get hit and generates a response before winston causes a problem.

This has already been done in the auth service 
`https://github.com/amida-tech/amida-auth-microservice/commit/9cdad08f34a2ccb9c3987175ee271e8a3d5bacf2`

It is also about to be pushed to the messaging service

To test just send an valid then invalid request and verify for the invalid request you get something back in the standard error format json. 