### PR TITLE
[ORANGE-453] Test no authorisation

### DIFF
--- a/server/tests/misc.spec.js
+++ b/server/tests/misc.spec.js
@@ -3,7 +3,8 @@
 import request from 'supertest-as-promised';
 import httpStatus from 'http-status';
 import chai, { expect } from 'chai';
-import app from '../../index';
+
+import { app, auth } from './common.integration.js';
 
 chai.config.includeStack = true;
 
@@ -17,13 +18,13 @@ describe('## Misc', () => {
     });
 
     describe('# GET /api/404', () => {
-        xit('should return 404 status', () => request(app)
+        it('should return 404 status', () => request(app)
             .get('/api/404')
+            .set('Authorization', `Bearer ${auth}`)
             .expect(httpStatus.NOT_FOUND)
             .then((res) => {
-                expect(res.body.code).to.equal('UNKNOWN_API');
-                expect(res.body.status).to.equal('ERROR');
-                expect(res.body.message).to.equal('API not found');
+                expect(res.status).to.equal(404);
+                expect(res.body.message).to.equal('Not Found');
             })
         );
     });

--- a/server/tests/user.integration.spec.js
+++ b/server/tests/user.integration.spec.js
@@ -46,6 +46,19 @@ describe('Notifications API:', () => {
     });
 
     describe('Create User and Update Device Token', () => {
+        it('Should fail without Authorization header', () => request(app)
+            .post(`${baseURL}/users`)
+            .send(testUserObject)
+            .expect(httpStatus.UNAUTHORIZED)
+        );
+
+        it('Should fail with badtoken in Authorization header', () => request(app)
+            .post(`${baseURL}/users`)
+            .set('Authorization', 'Bearer badtoken')
+            .send(testUserObject)
+            .expect(httpStatus.UNAUTHORIZED)
+        );
+
         it('should should create and respond with a user', () => request(app)
             .post(`${baseURL}/users`)
             .set('Authorization', `Bearer ${auth}`)


### PR DESCRIPTION
- Fixed "should return 404 status" (was `xit` / not used)
- Added "Should fail without Authorization header"
- Added "Should fail with badtoken in Authorization header"

```
yarn test
```

Should see three additional tests pass