### PR TITLE
encrypt DB conn when running migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## [Unreleased]
 
 
+## [1.4.1] -- 2018-02-26
+### Fixed
+- DB connection is now encrypted
+
+
 ## [1.4.0] -- 2018-02-11
 ### Added
 - Notifications are no longer sent to a signed out device

--- a/config/database.js
+++ b/config/database.js
@@ -1,4 +1,6 @@
-const postgres = require('./config').postgres;
+const Sequelize = require('sequelize');
+const postgres = require('./config.js').postgres;
+const { ensureConnectionIsEncrypted } = require('./helpers');
 
 const config = {
     username: postgres.user,
@@ -7,7 +9,31 @@ const config = {
     host: postgres.host,
     port: postgres.port,
     dialect: 'postgres',
+    migrationStorageTableName: 'sequelize_meta',
+    logging: true,
 };
+
+if (postgres.sslEnabled) {
+    config.ssl = postgres.sslEnabled;
+    if (postgres.sslCaCert) {
+        config.dialectOptions = {
+            ssl: {
+                ca: postgres.sslCaCert,
+                rejectUnauthorized: true,
+            },
+        };
+    }
+}
+
+// TODO ARH: This sequelize instance, using the config defined in this file,
+// exists only to check if this config results an a properly encrypted connection to Postgres.
+// The proper way to do it is to consolidate sequelize.js and database.js (this file) such that
+// they use the same sequelize instance. This is documented in ORANGE-897.
+const sequelize = new Sequelize(config);
+
+if (postgres.sslEnabled) {
+    ensureConnectionIsEncrypted(sequelize);
+}
 
 module.exports = {
     development: config,

--- a/config/helpers.js
+++ b/config/helpers.js
@@ -1,5 +1,6 @@
 // This file must not use anything that requires babel compilation because its
 // contents run without babel in some cases, such as when doing DB migrations.
+
 const logger = require('./winston');
 
 function ensureConnectionIsEncrypted(sequelize) {
@@ -11,16 +12,14 @@ function ensureConnectionIsEncrypted(sequelize) {
     })
     .catch((err) => {
         if (err.message === 'self signed certificate in certificate chain') {
-            logger.error({
-                message: `Sequelize is throwing error "${err.message}", which it does seemingly any time the certificate is invalid. Ensure your MESSAGING_SERVICE_PG_CA_CERT is set correctly. Aborting.`,
-                err,
-            });
+            logger.error(`Sequelize is throwing error "${err.message}", which it does seemingly any time the certificate is invalid. Ensure your NOTIFICATION_SERVICE_PG_CA_CERT is set correctly.`);
         } else {
-            logger.error(`Error attempting to verify the sequelize connection is SSL encrypted. Sequelize reports: "${err.message}". Aborting.`, { err });
+            logger.error(`Error attempting to verify the sequelize connection is SSL encrypted: ${err.message}`);
         }
         process.exit(1);
     });
 }
+
 module.exports = {
     ensureConnectionIsEncrypted,
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amida-notification-microservice",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Microservice for a lightweight notification application",
   "author": "Nick Mcally <nick@amida.com>",
   "main": "dist/index.js",


### PR DESCRIPTION
#### What's this PR do?

Other repos (Auth, Messaging) encrypt their DB connection when they run DB migrations. I added migrations to the notification service for the first time in release 1.4.0, but forgot to add this DB connection encryption code until now.

#### Related JIRA tickets:

N/A

#### How should this be manually tested?

