### PR TITLE
[SER-258] PG ssl.rejectUnauthorized unless CA env var provided and valid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
 ## [Unreleased]
-
+### Changed
+- PG connection will now fail (and this service will abort) if `NOTIFICATION_SERVICE_PG_SSL_ENABLED=true` but `NOTIFICATION_SERVICE_PG_CA_CERT` is not set to a valid value.
 
 ## [1.4.2] -- 2019-05-14
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -258,11 +258,25 @@ Password of postgres user `NOTIFICATION_SERVICE_PG_USER`.
 
 ##### `NOTIFICATION_SERVICE_PG_SSL_ENABLED` [`false`]
 
-Whether an SSL connection shall be used to connect to postgres.
+Whether an SSL connection shall be used to connect to postgres. If `true`, then `NOTIFICATION_SERVICE_PG_CA_CERT` (probably) must be set to a valid value (see nuance about override in description of this variable below).
 
 ##### `NOTIFICATION_SERVICE_PG_CA_CERT`
 
-If SSL is enabled with `NOTIFICATION_SERVICE_PG_SSL_ENABLED` this can be set to a certificate to override the CAs that are trusted while initiating the SSL connection to postgres. Without this set, Mozilla's list of trusted CAs is used. Note that this variable should contain the certificate itself, not a filename.
+If SSL is enabled with `NOTIFICATION_SERVICE_PG_SSL_ENABLED` this can be set to a certificate to override the CAs that are trusted while initiating the SSL connection to postgres. Without this set, Mozilla's list of trusted CAs is used.
+
+Note that this variable should contain the certificate itself, not a filename.
+
+Example usage with AWS RDS
+
+```
+# Download CA cert bundle for AWS RDS
+wget https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem
+```
+
+```
+# Start the server with the AWS RDS cert bundle
+NOTIFICATION_SERVICE_PG_CA_CERT=$(cat rds-combined-ca-bundle.pem) yarn start
+```
 
 ## Integration With Amida Auth Microservice
 

--- a/config/config.js
+++ b/config/config.js
@@ -68,7 +68,7 @@ if (error) {
     throw new Error(`Config validation error: ${error.message}`);
 }
 
-module.exports = {
+const config = {
     env: envVars.NODE_ENV,
     logLevel: envVars.LOG_LEVEL,
     port: envVars.NOTIFICATION_SERVICE_PORT,
@@ -97,3 +97,5 @@ module.exports = {
         sslCaCert: envVars.NOTIFICATION_SERVICE_PG_CA_CERT,
     },
 };
+
+module.exports = config;

--- a/config/database.js
+++ b/config/database.js
@@ -15,13 +15,13 @@ const config = {
 
 if (postgres.sslEnabled) {
     config.ssl = postgres.sslEnabled;
+    config.dialectOptions = {
+        ssl: {
+            rejectUnauthorized: true,
+        },
+    };
     if (postgres.sslCaCert) {
-        config.dialectOptions = {
-            ssl: {
-                ca: postgres.sslCaCert,
-                rejectUnauthorized: true,
-            },
-        };
+        config.dialectOptions.ssl.ca = postgres.sslCaCert;
     }
 }
 

--- a/config/sequelize.js
+++ b/config/sequelize.js
@@ -20,15 +20,16 @@ const sequelizeOptions = {
     host: config.postgres.host,
     logging: dbLogging,
 };
+
 if (config.postgres.sslEnabled) {
     sequelizeOptions.ssl = config.postgres.sslEnabled;
+    sequelizeOptions.dialectOptions = {
+        ssl: {
+            rejectUnauthorized: true,
+        },
+    };
     if (config.postgres.sslCaCert) {
-        sequelizeOptions.dialectOptions = {
-            ssl: {
-                ca: config.postgres.sslCaCert,
-                rejectUnauthorized: true,
-            },
-        };
+        sequelizeOptions.dialectOptions.ssl.ca = config.postgres.sslCaCert;
     }
 }
 


### PR DESCRIPTION
## What's this PR do?

See Jira ticket.

## Related JIRA tickets:

https://jira.amida.com/browse/SER-258

## How should this be manually tested?

*It is highly recommended that to test this you use a PG DB running in RDS.* This is because there is a CA cert bundle available for RDS (https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem)

Download this file. You will need it for `NOTIFICATION_SERVICE_PG_CA_CERT`.

If you need credentials to an RDS instance running Postgres, please let me know.

### Test 1: SSL Disabled...

- Set `NOTIFICATION_SERVICE_PG_SSL_ENABLED=false`
- It doesn't matter what you set `NOTIFICATION_SERVICE_PG_CA_CERT` to, or you can leave it unset.

### Test 1.1: SSL Disabled, testing `config/sequelize.js`

`yarn start`

It should connect to the DB (and you will get a message saying the server is running on port 4003).

### Test 1.2 SSL Disabled, testing `config/database.js`

Create a PG DB.

In your `.env` set `NOTIFICATION_SERVICE_PG_DB` to your new DB.

`yarn migrate`

It should connect to the DB (and you will get a message saying the server is running on port 4003).

### Test 2: No or a bad `NOTIFICATION_SERVICE_PG_CA_CERT`...

- Set `NOTIFICATION_SERVICE_PG_SSL_ENABLED=true`
- Don't set `NOTIFICATION_SERVICE_PG_CA_CERT` (feel free to repeat all these `Test 2` tests with `NOTIFICATION_SERVICE_PG_CA_CERT` set to any incorrect value; however note that this case was already working correctly, and this PR is intended to fix the case when `NOTIFICATION_SERVICE_PG_CA_CERT` is undefined).

#### Test 2.1 No or a bad `NOTIFICATION_SERVICE_PG_CA_CERT`, testing `config/sequelize.js`

`yarn start`

It should fail, print an error message like `2019-05-09T16:02:08.653Z error Sequelize is throwing error "self signed certificate in certificate chain", which it does seemingly any time the certificate is invalid. Ensure your NOTIFICATION_SERVICE_PG_CA_CERT is set correctly.` and crash the server.

#### Test 2.2 No or a bad `NOTIFICATION_SERVICE_PG_CA_CERT`, testing `config/database.js`

Create a PG DB.

In your `.env` set `NOTIFICATION_SERVICE_PG_DB` to your new DB.

`yarn migrate`

It should fail as above.

### Test 3 SSL Enabled and Working...

- Set `NOTIFICATION_SERVICE_PG_SSL_ENABLED=true`
- Set `NOTIFICATION_SERVICE_PG_CA_CERT` to the _contents_ of `rds-combined-ca-bundle.pem`. This cannot be put into a `.env` file, so the easiest way to set it is to do this: `NOTIFICATION_SERVICE_PG_CA_CERT=$(cat path/to/your/rds-combined-ca-bundle.pem) yarn whatever`

### Test 3.1 SSL Enabled and Working, testing `config/sequelize.js`

`yarn start`

It should work as in `Test 1`.

### Test 3.2 SSL Enabled and Working, testing `config/database.js`

Create a PG DB.

In your `.env` set `NOTIFICATION_SERVICE_PG_DB` to your new DB.

`yarn migrate`

It should work as in `Test 1` above.