### PR TITLE
[SER-288] /updateDevice handle incorrect username

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Changelog
 
 ## [Unreleased]
-### Changed
+### Fixed
 - PG connection will now fail (and this service will abort) if `NOTIFICATION_SERVICE_PG_SSL_ENABLED=true` but `NOTIFICATION_SERVICE_PG_CA_CERT` is not set to a valid value.
+- updateDevice handles incorrect username
+
 
 ## [1.4.2] -- 2019-05-14
 ### Fixed

--- a/server/controllers/users.controller.js
+++ b/server/controllers/users.controller.js
@@ -1,5 +1,7 @@
+import httpStatus from 'http-status';
 import Sequelize from 'sequelize';
 import db from '../../config/sequelize';
+import APIError from '../helpers/APIError';
 
 const User = db.User;
 const Device = db.Device;
@@ -22,9 +24,15 @@ function sendPushNotification(req, res, next) {  // eslint-disable-line no-unuse
     res.send(req.body);
 }
 
-function updateDevice(req, res, next) {  // eslint-disable-line no-unused-vars
+// eslint-disable-next-line no-unused-vars
+function updateDevice(req, res, next) {
     const { username, token, deviceType } = req.body;
+    // eslint-disable-next-line consistent-return
     User.findOne({ where: { username } }).then((deviceUser) => {
+        if (!deviceUser) {
+            return next(new APIError('User not found', httpStatus.NOT_FOUND, true));
+        }
+
         Device.destroy({
             where: {
                 token,


### PR DESCRIPTION
#### Related JIRA tickets:

https://jira.amida.com/browse/SER-288

#### What it does
- See Jira ticket.
- Now, no error is thrown, and instead you just get an HTTP status 404 with a message like "User not found"

#### How should this be manually tested?
- Use your auth service to get a JWT for your push notification service user

- Make this call (authenticated with your JWT):

`POST` to `http://localhost:4003/api/v1/users/updateDevice`
With body:
```json
{
	"username": "some_user_that_does_not_exist",
	"token": "does_not_matter",
	"deviceType": "does_not_matter"
}
```

- You should not get any error thrown
- You should get an HTTP 404 back and the response body message should be "User not found"
